### PR TITLE
Track cumulative claims instead of bitmap

### DIFF
--- a/src/BnetRefunder.sol
+++ b/src/BnetRefunder.sol
@@ -28,7 +28,7 @@ import {MerkleProof} from "./MerkleProof.sol";
 contract BnetRefunder is MerkleProof {
     address public owner;
     mapping(uint256 => bytes32) public roots;
-    mapping(uint256 => mapping(uint256 => uint256)) public claimedBitMap;
+    mapping(uint256 => mapping(address => uint256)) public claimed;
     uint256 latest;
 
     event Claim(uint256 epoch, uint256 index, uint256 amount) anonymous;
@@ -58,22 +58,19 @@ contract BnetRefunder is MerkleProof {
         uint256 amount,
         bytes32[] calldata merkleProof
     ) external {
-        // check leaf wasn't claimed
-        uint256 claimedWordIndex = index / 256;
-        uint256 claimedBitIndex = index % 256;
-        uint256 claimedWord = claimedBitMap[epoch][claimedWordIndex];
-        uint256 mask = (1 << claimedBitIndex);
-        require(claimedWord & mask == 0, "already claimed");
+        // check leaf wasn't claimed for ux
+        uint256 remaining = amount - claimed[epoch][account];
+        require(remaining > 0, "already claimed");
 
-        // mark leaf as claimed
-        claimedBitMap[epoch][claimedWordIndex] = claimedWord | mask;
+        // increment claimed amount for account
+        claimed[epoch][account] = amount;
 
         // verify proof
         bytes32 leaf = keccak256(abi.encodePacked(index, account, amount));
         require(verifyProof(merkleProof, roots[epoch], leaf), "invalid proof");
 
         // pay claim
-        account.transfer(amount);
+        account.transfer(remaining);
 
         emit Claim(epoch, index, amount);
     }

--- a/src/BnetRefunder.sol
+++ b/src/BnetRefunder.sol
@@ -29,9 +29,9 @@ contract BnetRefunder is MerkleProof {
     address public owner;
     mapping(uint256 => bytes32) public roots;
     mapping(uint256 => mapping(uint256 => uint256)) public claimedBitMap;
-    uint256 epoch;
+    uint256 latest;
 
-    event Claim(uint256 epoch_, uint256 index, uint256 amount) anonymous;
+    event Claim(uint256 epoch, uint256 index, uint256 amount) anonymous;
 
     modifier onlyOwner() {
         require(msg.sender == owner, "not owner");
@@ -42,17 +42,17 @@ contract BnetRefunder is MerkleProof {
         owner = msg.sender;
     }
 
-    function publish(uint256 epoch_, bytes32 root) external payable onlyOwner {
+    function publish(uint256 epoch, bytes32 root) external payable onlyOwner {
         // desire invariant msg.value = sum(leaf), but this is not checked here
         // if violated, race condition can occur
-        // roots can be updated, but only for current epoch
-        require(epoch_ >= epoch, "invalid epoch");
-        if (epoch_ != epoch) epoch = epoch_;
-        roots[epoch_] = root;
+        // roots can be updated, but only for latest epoch
+        require(epoch >= latest, "invalid epoch");
+        if (epoch != latest) latest = epoch;
+        roots[epoch] = root;
     }
 
     function claim(
-        uint256 epoch_,
+        uint256 epoch,
         uint256 index,
         address payable account,
         uint256 amount,
@@ -61,20 +61,20 @@ contract BnetRefunder is MerkleProof {
         // check leaf wasn't claimed
         uint256 claimedWordIndex = index / 256;
         uint256 claimedBitIndex = index % 256;
-        uint256 claimedWord = claimedBitMap[epoch_][claimedWordIndex];
+        uint256 claimedWord = claimedBitMap[epoch][claimedWordIndex];
         uint256 mask = (1 << claimedBitIndex);
         require(claimedWord & mask == 0, "already claimed");
 
         // mark leaf as claimed
-        claimedBitMap[epoch_][claimedWordIndex] = claimedWord | mask;
+        claimedBitMap[epoch][claimedWordIndex] = claimedWord | mask;
 
         // verify proof
         bytes32 leaf = keccak256(abi.encodePacked(index, account, amount));
-        require(verifyProof(merkleProof, roots[epoch_], leaf), "invalid proof");
+        require(verifyProof(merkleProof, roots[epoch], leaf), "invalid proof");
 
         // pay claim
         account.transfer(amount);
 
-        emit Claim(epoch_, index, amount);
+        emit Claim(epoch, index, amount);
     }
 }

--- a/src/BnetRefunder.sol
+++ b/src/BnetRefunder.sol
@@ -31,6 +31,8 @@ contract BnetRefunder is MerkleProof {
     mapping(uint256 => mapping(uint256 => uint256)) public claimedBitMap;
     uint256 epoch;
 
+    event Claim(uint256 epoch_, uint256 index, uint256 amount) anonymous;
+
     modifier onlyOwner() {
         require(msg.sender == owner, "not owner");
         _;
@@ -72,5 +74,7 @@ contract BnetRefunder is MerkleProof {
 
         // pay claim
         account.transfer(amount);
+
+        emit Claim(epoch_, index, amount);
     }
 }

--- a/src/BnetRefunder.sol
+++ b/src/BnetRefunder.sol
@@ -29,6 +29,7 @@ contract BnetRefunder is MerkleProof {
     address public owner;
     mapping(uint256 => bytes32) public roots;
     mapping(uint256 => mapping(uint256 => uint256)) public claimedBitMap;
+    uint256 epoch;
 
     modifier onlyOwner() {
         require(msg.sender == owner, "not owner");
@@ -39,15 +40,17 @@ contract BnetRefunder is MerkleProof {
         owner = msg.sender;
     }
 
-    function publish(uint256 epoch, bytes32 root) external payable onlyOwner {
+    function publish(uint256 epoch_, bytes32 root) external payable onlyOwner {
         // desire invariant msg.value = sum(leaf), but this is not checked here
         // if violated, race condition can occur
-        // roots can be updated, but you should only add leaves
-        roots[epoch] = root;
+        // roots can be updated, but only for current epoch
+        require(epoch_ >= epoch, "invalid epoch");
+        if (epoch_ != epoch) epoch = epoch_;
+        roots[epoch_] = root;
     }
 
     function claim(
-        uint256 epoch,
+        uint256 epoch_,
         uint256 index,
         address payable account,
         uint256 amount,
@@ -56,16 +59,16 @@ contract BnetRefunder is MerkleProof {
         // check leaf wasn't claimed
         uint256 claimedWordIndex = index / 256;
         uint256 claimedBitIndex = index % 256;
-        uint256 claimedWord = claimedBitMap[epoch][claimedWordIndex];
+        uint256 claimedWord = claimedBitMap[epoch_][claimedWordIndex];
         uint256 mask = (1 << claimedBitIndex);
         require(claimedWord & mask == 0, "already claimed");
 
         // mark leaf as claimed
-        claimedBitMap[epoch][claimedWordIndex] = claimedWord | mask;
+        claimedBitMap[epoch_][claimedWordIndex] = claimedWord | mask;
 
         // verify proof
         bytes32 leaf = keccak256(abi.encodePacked(index, account, amount));
-        require(verifyProof(merkleProof, roots[epoch], leaf), "invalid proof");
+        require(verifyProof(merkleProof, roots[epoch_], leaf), "invalid proof");
 
         // pay claim
         account.transfer(amount);

--- a/test/BnetRefunder.t.sol
+++ b/test/BnetRefunder.t.sol
@@ -116,28 +116,28 @@ contract BnetRefunderTest is Test {
         (, bytes32[] memory aliProof) = (new ProofMaker()).makeProof(accounts, amounts, 0);
 
         assertEq(ali.balance, 0);
-        Usr(ali).claim(0, 0, 1 ether, aliProof);
-        assertEq(ali.balance, 1 ether);
+        Usr(ali).claim(0, 0, amounts[0], aliProof);
+        assertEq(ali.balance, amounts[0]);
 
         (, bytes32[] memory bobProof) = (new ProofMaker()).makeProof(accounts, amounts, 1);
 
         assertEq(bob.balance, 0);
-        Usr(bob).claim(0, 1, 2 ether, bobProof);
-        assertEq(bob.balance, 2 ether);
+        Usr(bob).claim(0, 1, amounts[1], bobProof);
+        assertEq(bob.balance, amounts[1]);
 
         (, bytes32[] memory catProof) = (new ProofMaker()).makeProof(accounts, amounts, 2);
 
         assertEq(cat.balance, 0);
-        Usr(cat).claim(0, 2, 3 ether, catProof);
-        assertEq(cat.balance, 3 ether);
+        Usr(cat).claim(0, 2, amounts[2], catProof);
+        assertEq(cat.balance, amounts[2]);
     }
 
     function test_claim_on_behalf() public {
         (, bytes32[] memory aliProof) = (new ProofMaker()).makeProof(accounts, amounts, 0);
 
         assertEq(ali.balance, 0);
-        refunder.claim(0, 0, ali, 1 ether, aliProof);
-        assertEq(ali.balance, 1 ether);
+        refunder.claim(0, 0, ali, amounts[0], aliProof);
+        assertEq(ali.balance, amounts[0]);
     }
 
     function testRevert_no_publish_from_non_owner() public {
@@ -149,9 +149,9 @@ contract BnetRefunderTest is Test {
     function testRevert_no_claim_twice() public {
         (, bytes32[] memory bobProof) = (new ProofMaker()).makeProof(accounts, amounts, 1);
 
-        Usr(bob).claim(0, 1, 2 ether, bobProof);
+        Usr(bob).claim(0, 1, amounts[1], bobProof);
         vm.expectRevert();
-        Usr(bob).claim(0, 1, 2 ether, bobProof);
+        Usr(bob).claim(0, 1, amounts[1], bobProof);
     }
 
     function testRevert_no_claim_amount_greater() public {

--- a/test/BnetRefunder.t.sol
+++ b/test/BnetRefunder.t.sol
@@ -139,13 +139,14 @@ contract BnetRefunderTest is Test {
         Usr(ali).claim(0, 0, amounts[0], aliProof);
         assertEq(ali.balance, amounts[0]);
 
-        // adding a new leaf
-        accounts.push(cat);
-        amounts.push(1 ether);
+        // adding to a claimed leaf
+        amounts[0] += 1 ether;
+        // adding to an unclaimed leaf
+        amounts[2] += 1 ether;
 
         // calculate root using ali's account (arbitrary)
         (root,) = (new ProofMaker()).makeProof(accounts, amounts, 0);
-        refunder.publish{value: 1 ether}(0, root);
+        refunder.publish{value: 2 ether}(0, root);
 
         (, bytes32[] memory bobProof) = (new ProofMaker()).makeProof(accounts, amounts, 1);
 
@@ -159,11 +160,11 @@ contract BnetRefunderTest is Test {
         Usr(cat).claim(0, 2, amounts[2], catProof);
         assertEq(cat.balance, amounts[2]);
 
-        (, bytes32[] memory catProof2) = (new ProofMaker()).makeProof(accounts, amounts, 3);
+        (, bytes32[] memory aliProof2) = (new ProofMaker()).makeProof(accounts, amounts, 0);
 
-        assertEq(cat.balance, amounts[2]);
-        Usr(cat).claim(0, 3, amounts[3], catProof2);
-        assertEq(cat.balance, amounts[2] + amounts[3]);
+        assertEq(ali.balance, 1 ether);
+        Usr(ali).claim(0, 0, amounts[0], aliProof2);
+        assertEq(ali.balance, amounts[0]);
     }
 
     function test_claim_on_behalf() public {

--- a/test/BnetRefunder.t.sol
+++ b/test/BnetRefunder.t.sol
@@ -132,6 +132,40 @@ contract BnetRefunderTest is Test {
         assertEq(cat.balance, amounts[2]);
     }
 
+    function test_claims_incremental_update() public {
+        (, bytes32[] memory aliProof) = (new ProofMaker()).makeProof(accounts, amounts, 0);
+
+        assertEq(ali.balance, 0);
+        Usr(ali).claim(0, 0, amounts[0], aliProof);
+        assertEq(ali.balance, amounts[0]);
+
+        // adding a new leaf
+        accounts.push(cat);
+        amounts.push(1 ether);
+
+        // calculate root using ali's account (arbitrary)
+        (root,) = (new ProofMaker()).makeProof(accounts, amounts, 0);
+        refunder.publish{value: 1 ether}(0, root);
+
+        (, bytes32[] memory bobProof) = (new ProofMaker()).makeProof(accounts, amounts, 1);
+
+        assertEq(bob.balance, 0);
+        Usr(bob).claim(0, 1, amounts[1], bobProof);
+        assertEq(bob.balance, amounts[1]);
+
+        (, bytes32[] memory catProof) = (new ProofMaker()).makeProof(accounts, amounts, 2);
+
+        assertEq(cat.balance, 0);
+        Usr(cat).claim(0, 2, amounts[2], catProof);
+        assertEq(cat.balance, amounts[2]);
+
+        (, bytes32[] memory catProof2) = (new ProofMaker()).makeProof(accounts, amounts, 3);
+
+        assertEq(cat.balance, amounts[2]);
+        Usr(cat).claim(0, 3, amounts[3], catProof2);
+        assertEq(cat.balance, amounts[2] + amounts[3]);
+    }
+
     function test_claim_on_behalf() public {
         (, bytes32[] memory aliProof) = (new ProofMaker()).makeProof(accounts, amounts, 0);
 


### PR DESCRIPTION
Instead of tracking a bitmap of who has claimed as boolean, track the cumulative amount that has been claimed by each account (per epoch)

- this allows us to update the latest root while increasing the amounts at existing leaves, as opposed to only adding leaves. 
- the downside is that claims for first time users are 17k gas more expensive.
- the per-claim gas cost for users who have already claimed before remains the same.

Overall this should save gas for everyone who earns a refund more than once in their lifetime, since they will only have one leaf to prove and claim (per epoch) as opposed to having to request many small claims. For users who earn refunds over many transactions over time, the savings are very substantial.

The ux for users is also simpler, since they only need to find and prove one leaf in the tree (per epoch). The publisher code should be dead simple as well, with no need to track claims or logs.
